### PR TITLE
Added _get_link function and filter only amr detection analysis

### DIFF
--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -1,9 +1,10 @@
 import sys
 import argparse
 import logging
+import exceptions
+
 from version import __version__
 from irida_api import IridaAPI
-from urllib.error import HTTPError
 
 
 def init_argparser():
@@ -43,7 +44,7 @@ def main():
         logging.error("Please specify project(s) to scan for results.")
         sys.exit(1)
 
-    irida = IridaAPI("neptune", "6KlqQOEzEy55GBrQdIa28DE9wFk7Y9RkDRmYfCCUKR", "http://10.10.50.155:8080", "admin",
+    irida = IridaAPI("neptune", "6KlqQOEzEy55GBrQdIa28DE9wFk7Y9RkDRmYfCCUKR", "http://10.10.50.155:8080/api", "admin",
                      "Test123!")
 
     try:
@@ -53,15 +54,16 @@ def main():
     except ConnectionError as e:
         error_txt = f"Could not connect to IRIDA. Error: {e}"
         raise Exception(error_txt)
-    except HTTPError as e:
+    except exceptions.IridaKeyError as e:
         project_id = args_dict["project"]
         error_txt = f"The given project ID doesn't exist: {project_id}. "
         logging.error(error_txt)
-        raise Exception(error_txt + f"Error: {e}")
+        raise exceptions.IridaKeyError(error_txt + f"Error: {e}")
     except Exception as e:
         error_txt = f"An Error has occurred. Error: {e}"
         logging.error(error_txt)
         raise Exception(error_txt)
+
 
 # This is called when the program is run for the first time
 if __name__ == "__main__":

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -51,18 +51,14 @@ def main():
         amr_analyses = irida.get_amr_analysis_results(args_dict["project"])
 
     # TODO: better exception handler
-    except ConnectionError as e:
+    except exceptions.IridaConnectionError as e:
         error_txt = f"Could not connect to IRIDA. Error: {e}"
         raise Exception(error_txt)
-    except exceptions.IridaKeyError as e:
+    except exceptions.IridaResourceError as e:
         project_id = args_dict["project"]
         error_txt = f"The given project ID doesn't exist: {project_id}. "
         logging.error(error_txt)
         raise exceptions.IridaKeyError(error_txt + f"Error: {e}")
-    except Exception as e:
-        error_txt = f"An Error has occurred. Error: {e}"
-        logging.error(error_txt)
-        raise Exception(error_txt)
 
 
 # This is called when the program is run for the first time

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -48,7 +48,6 @@ def main():
 
     try:
         amr_analyses = irida.get_amr_analysis_results(args_dict["project"])
-        print(len(amr_analyses))
 
     # TODO: better exception handler
     except ConnectionError as e:

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -47,7 +47,8 @@ def main():
                      "Test123!")
 
     try:
-        amr_analyses = irida.get_amr_analyses(args_dict["project"])
+        amr_analyses = irida.get_amr_analysis_results(args_dict["project"])
+        print(len(amr_analyses))
 
     # TODO: better exception handler
     except ConnectionError as e:

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -47,7 +47,7 @@ def main():
                      "Test123!")
 
     try:
-        analyses = irida.get_analyses_from_projects(args_dict["project"])
+        amr_analyses = irida.get_amr_analyses(args_dict["project"])
 
     # TODO: better exception handler
     except ConnectionError as e:
@@ -62,7 +62,6 @@ def main():
         error_txt = f"An Error has occurred. Error: {e}"
         logging.error(error_txt)
         raise Exception(error_txt)
-
 
 # This is called when the program is run for the first time
 if __name__ == "__main__":

--- a/irida_staramr_results/exceptions/__init__.py
+++ b/irida_staramr_results/exceptions/__init__.py
@@ -1,0 +1,5 @@
+from exceptions.irida_connection_error import IridaConnectionError
+from exceptions.irida_key_error import IridaKeyError
+from exceptions.irida_resource_error import IridaResourceError
+from exceptions.irida_upload_canceled_exception import IridaUploadCanceledException
+from exceptions.file_error import FileError

--- a/irida_staramr_results/exceptions/__init__.py
+++ b/irida_staramr_results/exceptions/__init__.py
@@ -1,5 +1,4 @@
 from exceptions.irida_connection_error import IridaConnectionError
 from exceptions.irida_key_error import IridaKeyError
 from exceptions.irida_resource_error import IridaResourceError
-from exceptions.irida_upload_canceled_exception import IridaUploadCanceledException
 from exceptions.file_error import FileError

--- a/irida_staramr_results/exceptions/file_error.py
+++ b/irida_staramr_results/exceptions/file_error.py
@@ -1,0 +1,5 @@
+class FileError(KeyError):
+    """
+    Used when a file given to the api could not be accessed
+    """
+    pass

--- a/irida_staramr_results/exceptions/irida_connection_error.py
+++ b/irida_staramr_results/exceptions/irida_connection_error.py
@@ -1,0 +1,8 @@
+class IridaConnectionError(Exception):
+    """
+    This error is thrown when the api cannot connect to the IRIDA api
+    Either the server is unreachable or the credentials are invalid
+
+    All calls to the api should expect this error
+    """
+    pass

--- a/irida_staramr_results/exceptions/irida_key_error.py
+++ b/irida_staramr_results/exceptions/irida_key_error.py
@@ -1,0 +1,9 @@
+class IridaKeyError(KeyError):
+    """
+    This error will only happen when there is an issue with the api itself
+    It should not be able to happen based on user input
+
+    This could happen if the HATEOAS spec changes,
+    or the api has a bug in the implementation of it
+    """
+    pass

--- a/irida_staramr_results/exceptions/irida_resource_error.py
+++ b/irida_staramr_results/exceptions/irida_resource_error.py
@@ -1,0 +1,28 @@
+class IridaResourceError(Exception):
+    """
+    This error is thrown when the api tries to get a resource route that doesn't exist
+    or send data to a resource route that does not exist
+
+    All calls to the api should expect this error
+    """
+
+    def __init__(self, message, resource_id=None):
+        """Initialize a IridaResourceError.
+
+        Args:
+            message: the summary message that's causing the error.
+            errors: a more detailed list of errors.
+        """
+        self._message = message
+        self._resource_id = resource_id
+
+    @property
+    def message(self):
+        return self._message
+
+    @property
+    def resource_id(self):
+        return self._resource_id
+
+    def __str__(self):
+        return self.message

--- a/irida_staramr_results/irida_api.py
+++ b/irida_staramr_results/irida_api.py
@@ -202,7 +202,7 @@ class IridaAPI(object):
     def get_amr_analysis_results(self, project_id):
         """
         Get all AMR detection analysis results from a project id.
-        If nothing is found, it returns an empty array.
+        If no analysis results found in the project, it returns an empty array.
         :param project_id:
         :return analysis_result_list:
         """


### PR DESCRIPTION
# Description of changes (issue #2 & #11)
## _get_link()
- make use of [irida-uploader's _get_link function](https://github.com/phac-nml/irida-uploader/blob/development/iridauploader/api/api_calls.py#L234) which makes a call to a `target_url` and searches for a `target_key` (a reference link) to return a `href` (the link) of a resource. This allows for easier access to HATEOAS links from IRIDA REST API. 
- Fixes issue #11

## Filter AMR_DETECTION
- Added `get_amr_analysis_results` function:
  1. gets all analysis submission of the given project (raises an exception if the project does not exists)
  2. get all the analysis results of all the analysis submission retrieves
  3. filter only the analysis with `AMR_DETECTION` type (which resides in analysis result object) and return that.
  - This function uses the following helper methods:
    - `_get_analysis_submissions_from_projects`
    - `_get_all_analysis_results`
    - `_is_type_amr`

## Additional changes
- Handled exceptions
- Added exception subclasses