### PR TITLE
added argument -a to append all found analysis into a single file.

### DIFF
--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -81,7 +81,8 @@ def _append_file_data_to_existing_data_frames(results_files, data_frames):
     The data_frames can be an empty dict
     :param results_files: a list of files to be converted into dataframes, and added or appended to the data_frames dict
     :param data_frames: a dictionary of filename:dataframe pairs
-    :return: list of dataframe objects with data from input appended, one per unique file name
+    :return: an updated dictionary of dataframe objects containing the newly appended data per filename.
+             example: {'filename1':dataframe1, 'filename2':dataframe2, ...}
     """
 
     for file in results_files:

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -5,12 +5,13 @@ import logging
 import pandas as pd
 
 
-def download_all_results(irida_api, project_id, output_file_name):
+def download_all_results(irida_api, project_id, output_file_name, mode_append):
     """
     Main function for downloading StarAMR results to an excel file.
     :param irida_api:
     :param project_id:
     :param output_file_name:
+    :param mode_append: boolean, appends all file data together when True
     :return:
     """
 
@@ -21,18 +22,28 @@ def download_all_results(irida_api, project_id, output_file_name):
     if len(amr_completed_analysis_submissions) < 1:
         logging.warning(f"No completed amr analysis submission type for project id [{project_id}].")
 
-    for a in amr_completed_analysis_submissions:
-        result_files = irida_api.get_analysis_result_files(a["identifier"])
-        _write_to_excel(result_files, output_file_name)
+    if mode_append:
+        # In append mode, collect all the data into dataframes, one per unique file name, then write a single file.
+        data_frames = {}
+        for a in amr_completed_analysis_submissions:
+            result_files = irida_api.get_analysis_result_files(a["identifier"])
+            data_frames = _append_file_data_to_existing_data_frames(result_files, data_frames)
+        _write_data_frames_to_excel(data_frames, output_file_name)
+    else:
+        # Base case, write the collection of files into a file, one file per analysis
+        for a in amr_completed_analysis_submissions:
+            result_files = irida_api.get_analysis_result_files(a["identifier"])
+            data_frames = _files_to_data_frames(result_files)
+            _write_data_frames_to_excel(data_frames, output_file_name)
 
     logging.info(f"Download complete for project id [{project_id}].")
 
 
-def _write_to_excel(result_files, output_file_name):
+def _write_data_frames_to_excel(data_frames, output_file_name):
     """
-    Converts file contents to dataframe and writes it to the output file.
+    Writes data_frames to the output file.
     Each dataframe is appended as a separate sheet.
-    :param result_files:
+    :param data_frames:
     :param output_file_name:
     :return:
     """
@@ -46,13 +57,46 @@ def _write_to_excel(result_files, output_file_name):
     logging.info(f"Creating a new file {output_file_name}.")
     with pd.ExcelWriter(output_file_name, engine='xlsxwriter') as writer:
         # append data frame to file
-        for file in result_files:
-            file_content = file.get_contents()
-            file_sheet_name = file.get_sheet_name()
-
+        for file_sheet_name in data_frames:
             logging.info(f"Appending {file_sheet_name} data to {output_file_name}.")
-            data_frame = _convert_to_df(file_content)
-            data_frame.to_excel(writer, sheet_name=file_sheet_name, index=False)
+            data_frames[file_sheet_name].to_excel(writer, sheet_name=file_sheet_name, index=False)
+
+
+def _files_to_data_frames(results_files):
+    """
+    Accepts a list of results files and returns them as dictionary of filename:dataframe key:value pairs
+    :param results_files:
+    :return:
+    """
+    data_frames = {}
+    for file in results_files:
+        data_frames[file.get_sheet_name()] = _convert_to_df(file.get_contents())
+
+    return data_frames
+
+
+def _append_file_data_to_existing_data_frames(results_files, data_frames):
+    """
+    Accepts a list of results files and appends the data to a given list of data_frames.
+    The data_frames can be an empty dict
+    :param results_files: a list of files to be converted into dataframes, and added or appended to the data_frames dict
+    :param data_frames: a dictionary of filename:dataframe pairs
+    :return: list of dataframe objects with data from input appended, one per unique file name
+    """
+
+    for file in results_files:
+        file_sheet_name = file.get_sheet_name()
+        if file_sheet_name not in data_frames.keys():
+            # new file, new dataframe
+            data_frames[file_sheet_name] = _convert_to_df(file.get_contents())
+        else:
+            # appending data to existing dataframe
+            prev_data = data_frames[file_sheet_name]
+            curr_data = _convert_to_df(file.get_contents())
+            updated_data = prev_data.append(curr_data)
+            data_frames[file_sheet_name] = updated_data
+
+    return data_frames
 
 
 def _convert_to_df(file_content):

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -24,16 +24,20 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append):
 
     if mode_append:
         # In append mode, collect all the data into dataframes, one per unique file name, then write a single file.
+        logging.info(f"Append mode: Writing all results data in one output file...")
         data_frames = {}
         for a in amr_completed_analysis_submissions:
+            logging.info(f"Appending analysis [{a['name']}]. ")
             result_files = irida_api.get_analysis_result_files(a["identifier"])
             data_frames = _append_file_data_to_existing_data_frames(result_files, data_frames)
         _write_data_frames_to_excel(data_frames, output_file_name)
     else:
         # Base case, write the collection of files into a file, one file per analysis
+        logging.info(f"Non-append mode: Writing each results data per analysis in their separate output file...")
         for a in amr_completed_analysis_submissions:
             result_files = irida_api.get_analysis_result_files(a["identifier"])
             data_frames = _files_to_data_frames(result_files)
+            logging.info(f"Creating a file for analysis [{a['name']}]. ")
             _write_data_frames_to_excel(data_frames, output_file_name)
 
     logging.info(f"Download complete for project id [{project_id}].")
@@ -58,7 +62,7 @@ def _write_data_frames_to_excel(data_frames, output_file_name):
     with pd.ExcelWriter(output_file_name, engine='xlsxwriter') as writer:
         # append data frame to file
         for file_sheet_name in data_frames:
-            logging.info(f"Appending {file_sheet_name} data to {output_file_name}.")
+            logging.debug(f"Writing {file_sheet_name} data to {output_file_name}.")
             data_frames[file_sheet_name].to_excel(writer, sheet_name=file_sheet_name, index=False)
 
 
@@ -112,4 +116,3 @@ def _convert_to_df(file_content):
         data_frame = pd.read_csv(io.StringIO(file_content), delimiter="\t")
 
     return data_frame
-

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -29,6 +29,8 @@ def init_argparser():
                                  help="This is your IRIDA account password.")
     argument_parser.add_argument("-c", "--config", action='store', required=True,
                                  help='Required. Path to a configuration file. ')
+    argument_parser.add_argument("-a", "--append", action='store_true',
+                                 help="Append all analysis results to a single output file.")
 
     return argument_parser
 
@@ -51,7 +53,8 @@ def _validate_args(args):
             'password': args.password,
             'config': args.config,
             'project': args.project,
-            'output': args.output}
+            'output': args.output,
+            'append': args.append}
 
 
 def _parse_config(config_file_path):
@@ -124,7 +127,7 @@ def main():
     logging.info("Successfully connected to IRIDA API.")
 
     # Start downloading results
-    amr_downloader.download_all_results(irida_api, args_dict["project"], args_dict["output"])
+    amr_downloader.download_all_results(irida_api, args_dict["project"], args_dict["output"], args_dict["append"])
 
 
 # This is called when the program is run for the first time


### PR DESCRIPTION
When using `-a`/`--append` all found analysis will be appended into a single file, with each unique file name being grouped together.

I changed the functionality of the excel writing functionality a bit to promote reusability.
It now expects a dictionary of dataframes to write.
I added a function that converts the file data into dataframes.
It is effectively doing the same things, but allows the excel writing function to be used for both the normal mode and new append mode.