### PR TITLE
Date range filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,29 @@ IRIDA StarAMR Results program enables StarAMR analysis results that were run thr
 
 4. __Execute the program:__
     ```
-    > irida-staramr-results -u <IRIDA_USERNAME> -pw <IRIDA_PASSWORD> -c <CONFIG_FILE_PATH> -p <PROJECT> -o <OUTPUT_FILE_NAME>.xlsx
+    > irida-staramr-results -u <IRIDA_USERNAME> -pw <IRIDA_PASSWORD> -c <CONFIG_FILE_PATH> -p <PROJECT> -o <OUTPUT_FILE_NAME>.xlsx -fd 2021-04-08 -td 2021-04-21
     ```
 
-### Running Tests
+## Arguments
+
+#### Required:
+- `-u` or `--username`: This is your IRIDA account username.
+- `-pw` or `--password`: This is your IRIDA account password.
+- `-p` or `--project`: Project(s) to scan for StarAMR results.
+- `-o` or `--output`: The name of the output excel file.
+- `-c` or `--config`: Required. Path to a configuration file.
+
+#### Optional:
+- `-h` or `--help`: Show help message.
+- `-v` or `--version`: The current version of irida-staramr-results.
+- `-a` or `--append`: Append all analysis results to a single output file.
+- `-fd` or `--from_date`: Download only results of the analysis that were created FROM this date.*
+- `-td` or `--to_date`: Download only results of the analysis that were created UP UNTIL this date.*
+    
+__Notes:__ 
+- \* Dates are formatted as `YYYY-mm-dd` (eg. 2021-04-08) and includes hours from 00:00:00 to 23:59:59 of the inputted date.
+
+## Running Tests
 #### Unit test
 1. Running the unit tests can be done with the command:
     ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ IRIDA StarAMR Results program enables StarAMR analysis results that were run thr
 - `-td` or `--to_date`: Download only results of the analysis that were created UP UNTIL this date.*
     
 __Notes:__ 
-- \* Dates are formatted as `YYYY-mm-dd` (eg. 2021-04-08) and includes hours from 00:00:00 to 23:59:59 of the inputted date.
+- \* Dates are formatted as `YYYY-mm-dd` (eg. 2021-04-08) and include hours from 00:00:00 to 23:59:59 of the inputted date.
 
 ## Running Tests
 #### Unit test

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -30,12 +30,6 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append, f
         logging.warning(f"No completed amr analysis submission type for project id [{project_id}].")
         return
 
-    global _directory_name
-    _directory_name = "staramr-results-" + datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-    logging.info(f"Creating directory name {_directory_name} to store results files.")
-    os.mkdir(_directory_name)
-
-
     # Filter analysis created since target date (in timestamp)
     amr_completed_analysis_submissions = _filter_by_date(amr_completed_analysis_submissions, from_timestamp, to_timestamp)
 
@@ -45,6 +39,12 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append, f
         to_date = _timestamp_to_local(to_timestamp - 86400000)
         logging.warning(f"No completed amr analysis submission created from [{from_date}] to [{to_date}]. Exiting..")
         return
+
+    global _directory_name
+    _directory_name = "staramr-results-" + datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    logging.info(f"Creating directory name {_directory_name} to store results files.")
+    os.mkdir(_directory_name)
+
 
     if mode_append:
         # In append mode, collect all the data into dataframes, one per unique file name, then write a single file.

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -42,7 +42,7 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append, f
     if len(amr_completed_analysis_submissions) < 1:
 
         from_date = _timestamp_to_local(from_timestamp)
-        to_date = _timestamp_to_local(to_timestamp)
+        to_date = _timestamp_to_local(to_timestamp - 86400000)
         logging.warning(f"No completed amr analysis submission created from [{from_date}] to [{to_date}]. Exiting..")
         return
 

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -8,14 +8,15 @@ import pandas as pd
 _directory_name = ""
 
 
-def download_all_results(irida_api, project_id, output_file_name, mode_append, target_timestamp):
+def download_all_results(irida_api, project_id, output_file_name, mode_append, from_timestamp, to_timestamp):
     """
     Main function for downloading StarAMR results to an excel file.
     :param irida_api:
     :param project_id:
     :param output_file_name:
     :param mode_append: boolean, appends all file data together when True
-    :param target_timestamp:
+    :param from_timestamp:
+    :param to_timestamp:
     :return:
     """
 
@@ -35,8 +36,7 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append, t
 
 
     # Filter analysis created since target date (in timestamp)
-    amr_completed_analysis_submissions = [a for a in amr_completed_analysis_submissions
-                                          if a["createdDate"] >= target_timestamp]
+    amr_completed_analysis_submissions = _filter_by_date(amr_completed_analysis_submissions, from_timestamp, to_timestamp)
 
     if mode_append:
         # In append mode, collect all the data into dataframes, one per unique file name, then write a single file.
@@ -58,6 +58,25 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append, t
             _data_frames_to_excel(data_frames, out_name)
 
     logging.info(f"Download complete for project id [{project_id}].")
+
+
+def _filter_by_date(analysis, from_timestamp, to_timestamp):
+    """
+    Filters list of analysis objects with attribute "createdDate".
+    Returns a new list of analyses objects that were created between from_timestamp and to_timestamp
+    :param analysis:
+    :param from_timestamp: unix timestamp (float)
+    :param to_timestamp: unix timestamp (float)
+    :return:
+    """
+
+    analysis_filtered = []
+
+    for a in analysis:
+        if from_timestamp <= a["createdDate"] <= to_timestamp:
+            analysis_filtered.append(a)
+
+    return analysis_filtered
 
 
 def _get_output_file_name(prefix_name, timestamp):

--- a/irida_staramr_results/amr_downloader.py
+++ b/irida_staramr_results/amr_downloader.py
@@ -1,20 +1,21 @@
 import io
 import os
 import logging
-from datetime import datetime
 
+from datetime import datetime
 import pandas as pd
 
 _directory_name = ""
 
 
-def download_all_results(irida_api, project_id, output_file_name, mode_append):
+def download_all_results(irida_api, project_id, output_file_name, mode_append, target_timestamp):
     """
     Main function for downloading StarAMR results to an excel file.
     :param irida_api:
     :param project_id:
     :param output_file_name:
     :param mode_append: boolean, appends all file data together when True
+    :param target_timestamp:
     :return:
     """
 
@@ -32,6 +33,10 @@ def download_all_results(irida_api, project_id, output_file_name, mode_append):
     logging.info(f"Creating directory name {_directory_name} to store results files.")
     os.mkdir(_directory_name)
 
+
+    # Filter analysis created since target date (in timestamp)
+    amr_completed_analysis_submissions = [a for a in amr_completed_analysis_submissions
+                                          if a["createdDate"] >= target_timestamp]
 
     if mode_append:
         # In append mode, collect all the data into dataframes, one per unique file name, then write a single file.

--- a/irida_staramr_results/api/irida_api.py
+++ b/irida_staramr_results/api/irida_api.py
@@ -389,6 +389,7 @@ class IridaAPI(object):
             "staramr-summary.tsv",
             "staramr-plasmidfinder.tsv",
             "staramr-mlst.tsv"
+            "staramr-pointfinder.tsv"
         ]
 
         result_files = []

--- a/irida_staramr_results/api/irida_api.py
+++ b/irida_staramr_results/api/irida_api.py
@@ -389,7 +389,6 @@ class IridaAPI(object):
             "staramr-summary.tsv",
             "staramr-plasmidfinder.tsv",
             "staramr-mlst.tsv"
-            "staramr-pointfinder.tsv"
         ]
 
         result_files = []

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -31,9 +31,9 @@ def init_argparser():
                                  help="Required. Path to a configuration file. ")
     argument_parser.add_argument("-a", "--append", action="store_true",
                                  help="Append all analysis results to a single output file.")
-    argument_parser.add_argument("--fromDate", action="store",
+    argument_parser.add_argument("-fd", "--from_date", action="store",
                                  help="Download only results of the analysis that were created FROM this date.")
-    argument_parser.add_argument("--toDate", action="store",
+    argument_parser.add_argument("-td", "--to_date", action="store",
                                  help="Download only results of the analysis that were created UP UNTIL this date.")
 
 
@@ -57,7 +57,7 @@ def _validate_args(args):
     if args.output.endswith(".xlsx"):
         args.output = args.output[:-len(".xlsx")]
 
-    date = _validate_date(args.fromDate, args.toDate)
+    date_range = _validate_date(args.from_date, args.to_date)
 
     return {'username': args.username,
             'password': args.password,
@@ -65,8 +65,8 @@ def _validate_args(args):
             'project': args.project,
             'output': args.output,
             'append': args.append,
-            'fromDate': date["fromDate"],
-            'toDate': date["toDate"]}
+            'from_date': date_range["from_date"],
+            'to_date': date_range["to_date"]}
 
 
 def _validate_date(from_date, to_date):
@@ -80,29 +80,29 @@ def _validate_date(from_date, to_date):
     if from_date is None:
         from_date = 0
     else:
-        from_date = local_to_timestamp(from_date)
+        from_date = _local_to_timestamp(from_date)
 
     if to_date is None:
         to_date = time.time() * 1000
     else:
-        to_date = local_to_timestamp(to_date)
+        to_date = _local_to_timestamp(to_date)
 
     if (to_date > time.time() * 1000) or (from_date > time.time() * 1000):
-        logging.error("DateError: --fromDate and --toDate cannot be in the future.")
+        logging.error("DateError: --from_date and --to_date cannot be in the future.")
         sys.exit(1)
 
     if from_date > to_date:
-        logging.error("DateError: --fromDate must be earlier than --toDate.")
+        logging.error("DateError: --from_date must be earlier than --to_date.")
         sys.exit(1)
 
     # Add 24 hours (86400000 milliseconds) to include to_date's full day.
     to_date = to_date + 86400000
 
 
-    return {"fromDate": from_date, "toDate": to_date}
+    return {"from_date": from_date, "to_date": to_date}
 
 
-def local_to_timestamp(target_date):
+def _local_to_timestamp(target_date):
     """
     Converts date in local time to unix timestamp in milliseconds. Assumes "YYYY-mm-dd" is the input date format.
     :param target_date: string type formatted as YYYY-mm-dd
@@ -162,7 +162,7 @@ def main():
 
     # Start downloading results
     amr_downloader.download_all_results(irida_api, args_dict["project"], args_dict["output"], args_dict["append"],
-                                        args_dict["fromDate"], args_dict["toDate"])
+                                        args_dict["from_date"], args_dict["to_date"])
 
 
 # This is called when the program is run for the first time

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -109,8 +109,8 @@ def _local_to_timestamp(target_date):
     :return:
     """
 
-    dt = datetime.strptime(target_date, "%Y-%m-%d")  # local
-    dt_utc = dt.replace(tzinfo=timezone.utc)  # local -> utc
+    dt_local = datetime.strptime(target_date, "%Y-%m-%d")  # local
+    dt_utc = dt_local.replace(tzinfo=timezone.utc)  # local -> utc
     timestamp = dt_utc.timestamp() * 1000  # utc -> unix timestamp (millisecond)
 
     return timestamp

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -80,12 +80,12 @@ def _validate_date(from_date, to_date):
     if from_date is None:
         from_date = 0
     else:
-        from_date = utc_to_timestamp(from_date)
+        from_date = local_time_to_unix_timestamp(from_date)
 
     if to_date is None:
         to_date = time.time() * 1000
     else:
-        to_date = utc_to_timestamp(to_date)
+        to_date = local_time_to_unix_timestamp(to_date)
 
     if (to_date > time.time() * 1000) or (from_date > time.time() * 1000):
         logging.error("DateError: --fromDate and --toDate cannot be in the future.")
@@ -99,15 +99,16 @@ def _validate_date(from_date, to_date):
     return {"fromDate": from_date, "toDate": to_date}
 
 
-def utc_to_timestamp(target_date):
+def local_time_to_unix_timestamp(target_date):
     """
-    Converts date in UTC to unix timestamp in milliseconds. Assumes "YYYY-mm-dd" is the input date format.
-    :param target_date:
+    Converts date in local time to unix timestamp in milliseconds. Assumes "YYYY-mm-dd" is the input date format.
+    :param target_date: string type formatted as YYYY-mm-dd
     :return:
     """
 
-    dt = datetime.strptime(target_date, "%Y-%m-%d")
-    timestamp = dt.replace(tzinfo=timezone.utc).timestamp() * 1000
+    dt = datetime.strptime(target_date, "%Y-%m-%d")  # local
+    dt_utc = dt.replace(tzinfo=timezone.utc)  # local -> utc
+    timestamp = dt_utc.timestamp() * 1000  # utc -> unix timestamp (millisecond)
 
     return timestamp
 

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -25,10 +25,12 @@ def init_argparser():
                                  help="This is your IRIDA account username.")
     argument_parser.add_argument("-pw", "--password", action="store",
                                  help="This is your IRIDA account password.")
-    argument_parser.add_argument("-c", "--config", action='store', required=True,
-                                 help='Required. Path to a configuration file. ')
-    argument_parser.add_argument("-a", "--append", action='store_true',
+    argument_parser.add_argument("-c", "--config", action="store", required=True,
+                                 help="Required. Path to a configuration file. ")
+    argument_parser.add_argument("-a", "--append", action="store_true",
                                  help="Append all analysis results to a single output file.")
+    argument_parser.add_argument("-d", "--date", action="store",
+                                 help="Download only results of the analysis that were created since this date.")
 
     return argument_parser
 
@@ -54,7 +56,8 @@ def _validate_args(args):
             'config': args.config,
             'project': args.project,
             'output': args.output,
-            'append': args.append}
+            'append': args.append,
+            'date': args.date}
 
 
 def _init_api(args_dict, config_dict):
@@ -102,7 +105,8 @@ def main():
     logging.info("Successfully connected to IRIDA API.")
 
     # Start downloading results
-    amr_downloader.download_all_results(irida_api, args_dict["project"], args_dict["output"], args_dict["append"])
+    amr_downloader.download_all_results(irida_api, args_dict["project"], args_dict["output"], args_dict["append"],
+                                        args_dict["date"])
 
 
 # This is called when the program is run for the first time

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -45,7 +45,7 @@ def _validate_args(args):
     Validates argument input by the users and returns a dictionary of required information from arguments.
         - If user does not include username and password in arguments, the program prompts the user to enter it.
         - If user specify ".xlsx" for the output name, this method removes it.
-        - Converts date (in UTC) to unix timestamp. If not specified, it will be set to 0
+        - Validates date arguments (from and to)
     :param args:
     :return dictionary:
     """

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -95,6 +95,9 @@ def _validate_date(from_date, to_date):
         logging.error("DateError: --fromDate must be earlier than --toDate.")
         sys.exit(1)
 
+    # Add 24 hours (86400000 milliseconds) to include to_date's full day.
+    to_date = to_date + 86400000
+
 
     return {"fromDate": from_date, "toDate": to_date}
 

--- a/irida_staramr_results/cli.py
+++ b/irida_staramr_results/cli.py
@@ -80,12 +80,12 @@ def _validate_date(from_date, to_date):
     if from_date is None:
         from_date = 0
     else:
-        from_date = local_time_to_unix_timestamp(from_date)
+        from_date = local_to_timestamp(from_date)
 
     if to_date is None:
         to_date = time.time() * 1000
     else:
-        to_date = local_time_to_unix_timestamp(to_date)
+        to_date = local_to_timestamp(to_date)
 
     if (to_date > time.time() * 1000) or (from_date > time.time() * 1000):
         logging.error("DateError: --fromDate and --toDate cannot be in the future.")
@@ -99,7 +99,7 @@ def _validate_date(from_date, to_date):
     return {"fromDate": from_date, "toDate": to_date}
 
 
-def local_time_to_unix_timestamp(target_date):
+def local_to_timestamp(target_date):
     """
     Converts date in local time to unix timestamp in milliseconds. Assumes "YYYY-mm-dd" is the input date format.
     :param target_date: string type formatted as YYYY-mm-dd

--- a/irida_staramr_results/test_unit/test_amr_dowloader.py
+++ b/irida_staramr_results/test_unit/test_amr_dowloader.py
@@ -27,6 +27,10 @@ class AmrDownloader(unittest.TestCase):
         self.assertEqual(res_milli, "out-2021-01-19T21-13-14")
 
     def test_filter_by_date(self):
+        """
+        Tests function that filters analysis by date range
+        :return:
+        """
         fake_list = [
             {"createdDate": 1611122400000},  # Jan 20 2021
             {"createdDate": 1613282400000},  # Feb 14 2021

--- a/irida_staramr_results/test_unit/test_amr_dowloader.py
+++ b/irida_staramr_results/test_unit/test_amr_dowloader.py
@@ -1,6 +1,7 @@
 import unittest
+import time
 
-from irida_staramr_results.amr_downloader import _get_output_file_name
+from irida_staramr_results.amr_downloader import _get_output_file_name, _filter_by_date
 
 
 class AmrDownloader(unittest.TestCase):
@@ -11,21 +12,38 @@ class AmrDownloader(unittest.TestCase):
     def tearDown(self):
         pass
 
-
     def test_get_output_file(self):
         """
         Test output file name generation is correct.
         :return:
         """
 
+        fake_prefix_name = "out"
         fake_timestamp_in_millisec = 1611090794000
-        fake_timestamp_in_second = 1611090794
 
-        res_milli = _get_output_file_name(fake_timestamp_in_millisec)
-        res_sec = _get_output_file_name(fake_timestamp_in_second)
+        res_milli = _get_output_file_name(fake_prefix_name, fake_timestamp_in_millisec)
 
-        self.assertIn(".xlsx", res_milli)
-        self.assertEqual(res_milli, "2021-01-19T21-13-14.xlsx")
+        self.assertNotIn(".xlsx", res_milli)
+        self.assertEqual(res_milli, "out-2021-01-19T21-13-14")
 
-        self.assertTrue(".xlsx" in res_sec)
-        self.assertNotEqual(res_sec, "2021-01-19T21-13-14.xlsx")
+    def test_filter_by_date(self):
+        fake_list = [
+            {"createdDate": 1611122400000},  # Jan 20 2021
+            {"createdDate": 1613282400000},  # Feb 14 2021
+            {"createdDate": 1614405600000},  # Feb 27 2021
+            {"createdDate": 1614924000000},  # Mar 05 2021
+            {"createdDate": 1617858000000}  # Apr 08 2021
+        ]
+
+        # timestamps default values if user did not input any date (from and to)
+        fake_from_date_no_input = 0  # epoch
+        fake_to_date_no_input = time.time() * 1000  # now
+
+        fake_from_date = 1614319200000  # Feb 26 2021
+        fake_to_date = 1617771600000  # Apr 07 2021
+
+        res_no_input = _filter_by_date(fake_list, fake_from_date_no_input, fake_to_date_no_input)
+        res_input = _filter_by_date(fake_list, fake_from_date, fake_to_date)
+
+        self.assertEqual(len(res_no_input), 5)
+        self.assertEqual(len(res_input), 2)

--- a/irida_staramr_results/test_unit/test_cli.py
+++ b/irida_staramr_results/test_unit/test_cli.py
@@ -1,0 +1,62 @@
+import unittest
+
+from irida_staramr_results import cli
+
+
+class TestCli(unittest.TestCase):
+
+    def test_validate_date(self):
+
+        fake_from = "2021-04-08"  # UTC
+        fake_to = "2021-04-09"  # UTC
+
+        res = cli._validate_date(fake_from, fake_to)
+
+        self.assertIn("fromDate", res)
+        self.assertIn("toDate", res)
+        self.assertLess(res["fromDate"], res["toDate"])
+
+        self.assertEqual(res["fromDate"], 1617840000000.0)
+        self.assertEqual(res["toDate"], 1617926400000.0)
+
+        fake_from = None
+        fake_to = None
+
+        res = cli._validate_date(fake_from, fake_to)
+        self.assertEqual(0, res["fromDate"])
+
+    def test_utc_to_timestamp(self):
+        """
+        Test utc to timestamp conversion.
+        :return:
+        """
+        fake_good_date = "2021-04-08"
+        res = cli.utc_to_timestamp(fake_good_date)
+        self.assertEqual(res, 1617840000000.0)
+
+        fake_bad_date = "2021/04/08"
+        with self.assertRaises(ValueError) as c:
+            cli.utc_to_timestamp(fake_bad_date)
+            self.assertTrue("does not match format '%Y-%m-%d'" in c.exception)
+
+    def test_output_name_validation(self):
+
+        fake_filename_1 = "out"  # --> out.xlsx
+        fake_filename_2 = "out.xlsx"  # --> out.xlsx
+        fake_filename_2 = ""  # --> out.xlsx
+        fake_filename_3 = "xouts.xlsx"  # --> xouts.xlsx
+        fake_filename_4 = "out.xlsx.out"  # --> out.xlsx.out.xslx
+        fake_filename_5 = "out.xlxs"  # --> out.xslx.xlsx
+
+
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/irida_staramr_results/test_unit/test_cli.py
+++ b/irida_staramr_results/test_unit/test_cli.py
@@ -16,20 +16,20 @@ class TestCli(unittest.TestCase):
 
         res = cli._validate_date(fake_from, fake_to)
 
-        self.assertIn("fromDate", res)
-        self.assertIn("toDate", res)
-        self.assertLess(res["fromDate"], res["toDate"])
+        self.assertIn("from_date", res)
+        self.assertIn("to_date", res)
+        self.assertLess(res["from_date"], res["to_date"])
 
-        self.assertEqual(res["fromDate"], 1617840000000.0)
+        self.assertEqual(res["from_date"], 1617840000000.0)
 
         # the actual date plus one day
-        self.assertEqual(res["toDate"], 1617926400000.0 + 86400000)
+        self.assertEqual(res["to_date"], 1617926400000.0 + 86400000)
 
         fake_from = None
         fake_to = None
 
         res = cli._validate_date(fake_from, fake_to)
-        self.assertEqual(0, res["fromDate"])
+        self.assertEqual(0, res["from_date"])
 
     def test_local_to_timestamp(self):
         """
@@ -37,12 +37,12 @@ class TestCli(unittest.TestCase):
         :return:
         """
         fake_good_date = "2021-04-08"  # CDT
-        res = cli.local_to_timestamp(fake_good_date)
+        res = cli._local_to_timestamp(fake_good_date)
         self.assertEqual(res, 1617840000000.0)
 
         fake_bad_date = "2021/04/08"
         with self.assertRaises(ValueError) as c:
-            cli.local_to_timestamp(fake_bad_date)
+            cli._local_to_timestamp(fake_bad_date)
             self.assertTrue("does not match format '%Y-%m-%d'" in c.exception)
 
 

--- a/irida_staramr_results/test_unit/test_cli.py
+++ b/irida_staramr_results/test_unit/test_cli.py
@@ -7,8 +7,8 @@ class TestCli(unittest.TestCase):
 
     def test_validate_date(self):
 
-        fake_from = "2021-04-08"  # UTC
-        fake_to = "2021-04-09"  # UTC
+        fake_from = "2021-04-08"  # in local timezone
+        fake_to = "2021-04-09"  # in local timezone
 
         res = cli._validate_date(fake_from, fake_to)
 
@@ -25,28 +25,20 @@ class TestCli(unittest.TestCase):
         res = cli._validate_date(fake_from, fake_to)
         self.assertEqual(0, res["fromDate"])
 
-    def test_utc_to_timestamp(self):
+    def test_local_to_timestamp(self):
         """
-        Test utc to timestamp conversion.
+        Test local to timestamp conversion.
         :return:
         """
-        fake_good_date = "2021-04-08"
-        res = cli.utc_to_timestamp(fake_good_date)
+        fake_good_date = "2021-04-08"  # CDT
+        res = cli.local_to_timestamp(fake_good_date)
         self.assertEqual(res, 1617840000000.0)
 
         fake_bad_date = "2021/04/08"
         with self.assertRaises(ValueError) as c:
-            cli.utc_to_timestamp(fake_bad_date)
+            cli.local_to_timestamp(fake_bad_date)
             self.assertTrue("does not match format '%Y-%m-%d'" in c.exception)
 
-    def test_output_name_validation(self):
-
-        fake_filename_1 = "out"  # --> out.xlsx
-        fake_filename_2 = "out.xlsx"  # --> out.xlsx
-        fake_filename_2 = ""  # --> out.xlsx
-        fake_filename_3 = "xouts.xlsx"  # --> xouts.xlsx
-        fake_filename_4 = "out.xlsx.out"  # --> out.xlsx.out.xslx
-        fake_filename_5 = "out.xlxs"  # --> out.xslx.xlsx
 
 
 

--- a/irida_staramr_results/test_unit/test_cli.py
+++ b/irida_staramr_results/test_unit/test_cli.py
@@ -6,6 +6,10 @@ from irida_staramr_results import cli
 class TestCli(unittest.TestCase):
 
     def test_validate_date(self):
+        """
+        Test _validate_date function to return as expected
+        :return:
+        """
 
         fake_from = "2021-04-08"  # in local timezone
         fake_to = "2021-04-09"  # in local timezone
@@ -38,16 +42,6 @@ class TestCli(unittest.TestCase):
         with self.assertRaises(ValueError) as c:
             cli.local_to_timestamp(fake_bad_date)
             self.assertTrue("does not match format '%Y-%m-%d'" in c.exception)
-
-
-
-
-
-
-
-
-
-
 
 
 if __name__ == '__main__':

--- a/irida_staramr_results/test_unit/test_cli.py
+++ b/irida_staramr_results/test_unit/test_cli.py
@@ -21,7 +21,9 @@ class TestCli(unittest.TestCase):
         self.assertLess(res["fromDate"], res["toDate"])
 
         self.assertEqual(res["fromDate"], 1617840000000.0)
-        self.assertEqual(res["toDate"], 1617926400000.0)
+
+        # the actual date plus one day
+        self.assertEqual(res["toDate"], 1617926400000.0 + 86400000)
 
         fake_from = None
         fake_to = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ setuptools
 pyyaml
 pandas
 xlsxwriter
+dateutil


### PR DESCRIPTION
# Summary of changes

- Added **optional** arguments: `--fromDate` and `--toDate`
    - which specifies to download analysis created within (inclusive) the date range.
    - validates the date upfront before 
        - check if valid
        - converts to unix timestamp.
            - default values of `fromDate` and `toDate` are **0** (unix epoch) and **current unix timestamp**, respectively.


      For example:
      ```
      irida-staramr-results -p 1 --fromDate 2021-01-04  --toDate 2021-03-18 -u irida-user -pw pasword1 -o out.xlsx
      ```
      
      This will export results from project 1, only exporting those results from analysis ran between 
      **January 4, 2021** and **March 18, 2020**, inclusive.

- Added logging warning message if no analysis to be downloaded. No directory and files are created.
    > ` WARNING:root:No completed amr analysis submission created from [2021-04-06] to [2021-04-07]. Exiting..`

- Added time conversions functions
- More unit tests
   